### PR TITLE
geom_point

### DIFF
--- a/R/geom_point
+++ b/R/geom_point
@@ -1,0 +1,49 @@
+
+### geom_point()
+
+#### Description
+
+The geom_point call is an example of aesthetic mapping. It is a geom function used in conjunction with ggplot to display two continuous variables as scatterplots. Geom_point will inherit the data and aesthetic mapping from ggplot, and visa versa, so data only has to be input once.
+
+#### Usage
+
+ggplot(data(aes(x,y)) + geom_point(x,y, alpha, color, fill, shape, size, stroke)
+
+### Arguments
+
+aes()      aesthetic mapping.
+
+data       data frame used for scatterplot; inherited from ggplot.
+
+x          specify which variable should be drawn on the x axis.
+
+y          specify which variable should be drawn on the y axis.
+
+alpha      opacity; written as a fraction ranging from 0 to 1. It an also be combined with color or fill RGB values through "#RRGGBBAA" where AA = alpha value.
+
+color      outer line color of point; can be defined by a variable, color name, or hex code.
+
+fill       color inside of point; can be defined by a variable, color name, or hex code. Only shapes 21 - 24 allow for fill.
+
+shape      the shape of point; can be identified by an integer, name of shape, or a single character.
+
+size       size of point; identified by an integer. The default size is 1.5
+
+stroke     border width of point; identified by integer.
+
+#### examples
+
+ggplot(data = US_data, aes(x = lifeExp, y = gdpPercap)) +
+  geom_point(shape = 23, color="purple", fill="white") +
+  labs(x = "Life Expectancy", y = "GDP Per Capita")
+
+ggplot(data = starwars, aes(x = species, y = height)) +
+  geom_point(shape = 21, colour = "#33CCFF", fill = "pink", size = 3, stroke = 1)
+
+# you can also layer points to include different identifying variables:
+
+ggplot(data = US_data, aes(x = lifeExp, y = gdpPercap)) +
+  geom_point(aes(colour = year), size = 5) +
+  geom_point(colour = "grey") +
+  labs(x = "Life Expectancy", y = "GDP Per Capita")
+


### PR DESCRIPTION
### geom_point()

#### Description

The geom_point call is an example of aesthetic mapping. It is a geom function used in conjunction with ggplot to display two continuous variables as scatterplots. Geom_point will inherit the data and aesthetic mapping from ggplot, and visa versa, so data only has to be input once.

#### Usage

ggplot(data(aes(x,y)) + geom_point(x,y, alpha, color, fill, shape, size, stroke)

#### Arguments

aes() : aesthetic mapping.

data: data frame used for scatterplot; inherited from ggplot.

#### Aesthetic Values

x: specify which variable should be drawn on the x axis.

y: specify which variable should be drawn on the y axis.

alpha: opacity; written as a fraction ranging from 0 to 1. It an also be combined with color or fill RGB values through "#RRGGBBAA" where AA = alpha value.

color: outer line color of point; can be defined by a variable, color name, or hex code.

fill: color inside of point; can be defined by a variable, color name, or hex code. Only shapes 21 - 24 allow for fill.

shape: the shape of point; can be identified by an integer, name of shape, or a single character.

size: size of point; identified by an integer. The default size is 1.5

stroke: border width of point; identified by integer.

#### examples

ggplot(data = US_data, aes(x = lifeExp, y = gdpPercap)) +
  geom_point(shape = 23, color="purple", fill="white") +
  labs(x = "Life Expectancy", y = "GDP Per Capita")

ggplot(data = starwars, aes(x = species, y = height)) +
  geom_point(shape = 21, colour = "#33CCFF", fill = "pink", size = 3, stroke = 1)

#you can also layer points to include different identifying variables:

ggplot(data = US_data, aes(x = lifeExp, y = gdpPercap)) +
  geom_point(aes(colour = year), size = 5) +
  geom_point(colour = "grey") +
  labs(x = "Life Expectancy", y = "GDP Per Capita")