### PR TITLE
Create lag function

### DIFF
--- a/R/lag function
+++ b/R/lag function
@@ -1,0 +1,46 @@
+#' lag, lead, and diff for panel data
+#' 
+#' @Description
+#' 
+#' Compute a lagged version of a time series, shifting the time base back by a given number of observations.
+#' 
+#' @Usage
+#' "lag"(x, k = 1, ...)
+#' 
+#' "lead"(x, k = 1, ...)
+#' 
+#' "diff"(x, lag = 1, ...)
+#' 
+#' @Arguments
+#' x: a pseries object
+#' 
+#' k: an integer vector, the number of lags for the lag and lead methods (can also be negative). For the lag method, a positive (negative) k gives lagged (leading) values. For the lead method, a positive (negative) k gives leading (lagged) values, thus, lag(x, k = -1) yields the same as lead(x, k = 1). If k is an integer vector with length > 1 (k = c(k1, k2, ...)) a matrix with multiple lagged pseries is returned.
+#' 
+#' lag: the number of lags for the diff method (only non--negative values for parameter lag are allowed in diff)
+#' 
+#' @Examples
+#' 
+#' # First, create a pdata.frame
+#' 
+#' data("EmplUK", package = "plm")
+#' Em <- pdata.frame(EmplUK)
+#' 
+#' # Then extract a series, which becomes additionally a pseries
+#' 
+#' z <- Em$output
+#' class(z)
+#' 
+#' # compute the first and third lag, and the difference lagged twice
+#' 
+#' lag(z)
+#' lag(z, 3)
+#' diff(z, 2)
+#' 
+#' # compute negative lags (= leading values)
+#' lag(z, -1)
+#' lead(z, 1) # same as line above
+#' identical(lead(z, 1), lag(z, -1)) # TRUE
+#' 
+#' # compute more than one lag at once
+#' 
+#' lag(z, c(1,2))


### PR DESCRIPTION
#' lag, lead, and diff for panel data
#' 
#' @Description
#' 
#' Compute a lagged version of a time series, shifting the time base back by a given number of observations.
#' 
#' @Usage
#' "lag"(x, k = 1, ...)
#' 
#' "lead"(x, k = 1, ...)
#' 
#' "diff"(x, lag = 1, ...)
#' 
#' @Arguments
#' x: a pseries object
#' 
#' k: an integer vector, the number of lags for the lag and lead methods (can also be negative). For the lag method, a positive (negative) k gives lagged (leading) values. For the lead method, a positive (negative) k gives leading (lagged) values, thus, lag(x, k = -1) yields the same as lead(x, k = 1). If k is an integer vector with length > 1 (k = c(k1, k2, ...)) a matrix with multiple lagged pseries is returned.
#' 
#' lag: the number of lags for the diff method (only non--negative values for parameter lag are allowed in diff)
#' 
#' @Examples
#' 
#' # First, create a pdata.frame
#' 
#' data("EmplUK", package = "plm")
#' Em <- pdata.frame(EmplUK)
#' 
#' # Then extract a series, which becomes additionally a pseries
#' 
#' z <- Em$output
#' class(z)
#' 
#' # compute the first and third lag, and the difference lagged twice
#' 
#' lag(z)
#' lag(z, 3)
#' diff(z, 2)
#' 
#' # compute negative lags (= leading values)
#' lag(z, -1)
#' lead(z, 1) # same as line above
#' identical(lead(z, 1), lag(z, -1)) # TRUE
#' 
#' # compute more than one lag at once
#' 
#' lag(z, c(1,2))